### PR TITLE
Incorrectly placed .Nd macro

### DIFF
--- a/scponly.8
+++ b/scponly.8
@@ -4,9 +4,9 @@
 .Dt scponly 8
 .Sh NAME
 .Nm scponly
+.Nd limited shell for secure file transfers
 .Sh SYNOPSIS
 .Nm
-.Nd limited shell for secure file transfers
 .Sh DESCRIPTION
 .Nm
 is an alternative "shell" (of sorts) for system administrators who would like


### PR DESCRIPTION
The .Nd macro is supposed to appear in the .Sh NAME section rather than anywhere else